### PR TITLE
feat: drop Node 8 & 10 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         eslint: [6]
-        node: [8, 10, 12, 14, 16, 18]
+        node: [12.22.0, 12, 14.17.0, 14, 16, 18]
         include:
           # On other platforms
           - os: windows-latest
@@ -23,7 +23,7 @@ jobs:
             node: 18
           # On the minimum supported ESLint/Node.js version
           - eslint: 6.6.0
-            node: 8.10.0
+            node: 12.22.0
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,21 +10,35 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12.x, 10.x, 8.x]
+        os: [ubuntu-latest]
+        eslint: [6]
+        node: [8, 10, 12, 14, 16, 18]
+        include:
+          # On other platforms
+          - os: windows-latest
+            node: 18
+          - os: macos-latest
+            node: 18
+          # On the minimum supported ESLint/Node.js version
+          - eslint: 6.6.0
+            node: 8.10.0
+
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v3
       - name: Install Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Install Packages
         run: npm install
+        env:
+          CI: true
+      - name: Install ESLint@${{  matrix.eslint  }}
+        run: npm install eslint@${{  matrix.eslint  }}
       - name: Test
         run: npm test
       - name: Send Coverage

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ npm install --save-dev eslint @mysticatea/eslint-plugin
 
 ### Requirements
 
-- Node.js `^8.10.0` or newer versions.
-- ESLint `^6.3.0` or newer versions.
+- Node.js `^12.22.0 || ^14.17.0 || >=16.0.0` or newer versions.
+- ESLint `^6.6.0` or newer versions.
 
 ## 📖 Usage
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "13.0.0",
   "description": "Additional ESLint rules.",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "main": "index.js",
   "files": [


### PR DESCRIPTION
- In order to properly support ESLint 7.x and upwards, we need to start using `@eslint/eslintrc` (at least `v0.4.3`): `@eslint/eslintrc/lib/config-array-factory` instead of `eslint/lib/cli-engine/config-array-factory`.
  This however needs `Node@^10.12.0 || 12.0.0`.
  https://github.com/eslint/eslintrc/blob/9bf2ba12e6c0bfe7296774531fd79dea23d4c805/package.json#L60-L62

- If we want to update our `@typescript-eslint/*` dependency to v3, we also need `Node@^10.12.0 || 12.0.0`
  https://github.com/typescript-eslint/typescript-eslint/blob/43b1201a73687e29f19a16b0b26f68569f3c7a2e/package.json#L65-L67

- If we want to update our `eslint-plugin-eslint-plugin` dependency to v3, we also need `Node@^10.12.0 || 12.0.0`
  https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/cc58d764f3c3c342dcb7551c3f4e00abdd32fe19/package.json#L63-L65

- If we want to update our `prettier` dependency to v2, we need `Node@>=10.13.0`
  https://github.com/prettier/prettier/blob/2afc3b9ae674ede93489b55ab3f90ba2bcdd27c5/package.json#L13-L15

- Node 8 is EOL, so it's a good practice to not support it anymore.

- Node 10 is EOL, so it's a good practice to not support it anymore. 

- ESLint 7.x requires `Node@^10.12.0 || >=12.0.0` and imo it's a good practice to keep the Node version equal to that of the latest supported ESLint version
  https://github.com/eslint/eslint/blob/83cc8a6823d7729297b6814a644cca770cb99dbb/package.json#L143-L145

---

BREAKING CHANGE: Requires Node@^12.22.0 || ^14.17.0 || >=16.0.0

This branch is dependent on #33

CC/ @voxpelli